### PR TITLE
Faster version

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,9 @@
 export default function (obj) {
-	var k, cls='';
+	var cls, k
 	for (k in obj) {
 		if (obj[k]) {
-			cls && (cls += ' ');
-			cls += k;
+			cls = cls == null ? cls : cls + ' ' + k;
 		}
 	}
-	return cls;
+	return cls || '';
 }


### PR DESCRIPTION
It's a faster version, that I use in my [classies lib](https://github.com/StephanHoyer/classies) that pretty much does the same thing.

Performance is up the the ternary-compiled version
<img width="1176" alt="Screenshot 2022-01-27 at 09 01 35" src="https://user-images.githubusercontent.com/54701/151316466-f78e8f71-053c-4c9a-a9d3-e2c22006dd21.png">

It's even faster than the compiled version if you don't want to have a leading space (which you probably don't) so it makes the compile step pretty much useless 🤷‍♀️