### PR TITLE
obj-str build cls=[] via .push then => cls.join

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,9 @@
 export default function (obj) {
-	var k, cls='';
+	var k, cls=[];
 	for (k in obj) {
 		if (obj[k]) {
-			cls && (cls += ' ');
-			cls += k;
+			cls.push(k);
 		}
 	}
-	return cls;
+	return cls.join(" ");
 }


### PR DESCRIPTION
Instead of this:
```
export default function (obj) {
	var k, cls='';
	for (k in obj) {
		if (obj[k]) {
			cls && (cls += ' ');
			cls += k;
		}
	}
	return cls;
}
```

Use this more clear logic:
```
export default function (obj) {
	var k, cls=[];
	for (k in obj) {
		if (obj[k]) {
			cls.push(k);
		}
	}
	return cls.join(" ");
}
```